### PR TITLE
Improved PairAction to avoid duplicate end pair symbols

### DIFF
--- a/src/main/resources/de/sciss/syntaxpane/syntaxkits/javascriptsyntaxkit/config.properties
+++ b/src/main/resources/de/sciss/syntaxpane/syntaxkits/javascriptsyntaxkit/config.properties
@@ -8,8 +8,8 @@ Action.execute-script.ToolTip = Execute JavaScript in internal JRE
 Action.execute-script.SmallIcon = play.png
 
 Action.indent.WordRegex=\\w+|\\/(\\*)+
-Action.parenthesis = de.sciss.syntaxpane.actions.PairAction, typed (
-Action.brackets = de.sciss.syntaxpane.actions.PairAction, typed [
+Action.parenthesis = de.sciss.syntaxpane.actions.PairAction, typed (, typed )
+Action.brackets = de.sciss.syntaxpane.actions.PairAction, typed [, typed ]
 Action.quotes = de.sciss.syntaxpane.actions.PairAction, typed '
 Action.double-quotes = de.sciss.syntaxpane.actions.PairAction, typed "
 Action.close-curly = de.sciss.syntaxpane.actions.JUnindentAction, typed }

--- a/src/main/resources/de/sciss/syntaxpane/syntaxkits/javasyntaxkit/config.properties
+++ b/src/main/resources/de/sciss/syntaxpane/syntaxkits/javasyntaxkit/config.properties
@@ -14,11 +14,11 @@ RightMarginColor = 0xdddddd
 #
 # Java Actions
 Action.indent.WordRegex=\\w+|\\/(\\*)+
-Action.parenthesis = de.sciss.syntaxpane.actions.PairAction, typed (
+Action.parenthesis = de.sciss.syntaxpane.actions.PairAction, typed (, typed )
 Action.toggle-token-marker = de.sciss.syntaxpane.actions.ToggleComponentAction, control F3
 Action.toggle-token-marker.MenuText = Toggle Token Marker
 Action.toggle-token-marker.Component = de.sciss.syntaxpane.components.TokenMarker
-Action.brackets = de.sciss.syntaxpane.actions.PairAction, typed [
+Action.brackets = de.sciss.syntaxpane.actions.PairAction, typed [, typed ]
 Action.quotes = de.sciss.syntaxpane.actions.PairAction, typed '
 Action.double-quotes = de.sciss.syntaxpane.actions.PairAction, typed "
 Action.close-curly = de.sciss.syntaxpane.actions.JUnindentAction, typed }

--- a/src/main/resources/de/sciss/syntaxpane/syntaxkits/luasyntaxkit/config.properties
+++ b/src/main/resources/de/sciss/syntaxpane/syntaxkits/luasyntaxkit/config.properties
@@ -8,8 +8,8 @@ Action.combo-completion.MenuText = Completions
 Action.combo-completion.ItemsURL=${class_path}/combocompletions.txt
 
 # auto fill-in actions
-Action.parenthesis = de.sciss.syntaxpane.actions.PairAction, typed (
-Action.brackets = de.sciss.syntaxpane.actions.PairAction, typed [
+Action.parenthesis = de.sciss.syntaxpane.actions.PairAction, typed (, typed )
+Action.brackets = de.sciss.syntaxpane.actions.PairAction, typed [, typed ]
 Action.quotes = de.sciss.syntaxpane.actions.PairAction, typed '
 Action.double-quotes = de.sciss.syntaxpane.actions.PairAction, typed "
 Action.close-curly = de.sciss.syntaxpane.actions.JUnindentAction, typed }


### PR DESCRIPTION
If manually typing the end parenthesis or quote, the generated end symbol is overwritten

This fix works but it is not perfect. For example quoted strings like "\"" are not handled well, but that kind of logic would make the PairAction even more language dependent which seems dubious. The documentlistener is set up outside the install method because (at least in our application) the document is changed after this point.